### PR TITLE
Added repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
 		"node": ">=8.11",
 		"npm": ">=5.6"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Socialbakers/BakeryJS.git"
+	},
 	"dependencies": {
 		"ajv": "^6.5.4",
 		"async": "^2.6.1",


### PR DESCRIPTION
`npm install` yields a warning when there's a repo missing + it's not too bad to have one here anyway