### PR TITLE
Support componentsPath without slash

### DIFF
--- a/src/lib/bakeryjs/ComponentFactory.ts
+++ b/src/lib/bakeryjs/ComponentFactory.ts
@@ -80,13 +80,18 @@ export class ComponentFactory implements ComponentFactoryI {
 		componentsPath: string,
 		parentDir: string = ''
 	): void {
-		const files = fs.readdirSync(componentsPath);
+		const componentsPathSanit = componentsPath.endsWith('/')
+			? componentsPath
+			: `${componentsPath}/`;
+		const files = fs.readdirSync(componentsPathSanit);
 		files.forEach(
 			(file: string): void => {
-				if (fs.statSync(`${componentsPath}${file}`).isDirectory()) {
+				if (
+					fs.statSync(`${componentsPathSanit}${file}`).isDirectory()
+				) {
 					if (file !== '.' && file !== '..') {
 						this.findComponents(
-							`${componentsPath}${file}/`,
+							`${componentsPathSanit}${file}/`,
 							`${parentDir}${file}/`
 						);
 					}
@@ -95,7 +100,9 @@ export class ComponentFactory implements ComponentFactoryI {
 					if (name == null) {
 						return;
 					}
-					this.availableComponents[name] = `${componentsPath}${file}`;
+					this.availableComponents[
+						name
+					] = `${componentsPathSanit}${file}`;
 				}
 			}
 		);

--- a/src/lib/bakeryjs/__tests__/ComponentFactory.test.ts
+++ b/src/lib/bakeryjs/__tests__/ComponentFactory.test.ts
@@ -9,21 +9,26 @@ const serviceProvider = new ServiceProvider({
 	},
 });
 
-const componentsDir = resolve(__dirname, '..', '..', '..', 'components') + '/';
-const componentsDirWSlash = resolve(__dirname, '..', '..', '..', 'components');
-const testDataDir =
-	resolve(__dirname, '..', '..', '..', '..', 'test-data') + '/';
+const componentsDir = resolve(__dirname, '../../../components');
+const componentsDirSlash = componentsDir + '/';
+const testDataDir = resolve(__dirname, '../../../../test-data') + '/';
 
 describe('Component Factory', () => {
 	it('create builtin box', async () => {
-		const factory = new ComponentFactory(componentsDir, serviceProvider);
+		const factory = new ComponentFactory(
+			componentsDirSlash,
+			serviceProvider
+		);
 
 		const tickBox = await factory.create('tick');
 		expect(tickBox).not.toBeUndefined();
 	});
 
 	it('create nonexistent box throws', () => {
-		const factory = new ComponentFactory(componentsDir, serviceProvider);
+		const factory = new ComponentFactory(
+			componentsDirSlash,
+			serviceProvider
+		);
 
 		factory.create('fick').catch((reason) => {
 			expect.assertions(2);
@@ -35,7 +40,7 @@ describe('Component Factory', () => {
 	describe('Component Factory -- path without ending slash', () => {
 		it('create builtin box', async () => {
 			const factory = new ComponentFactory(
-				componentsDirWSlash,
+				componentsDir,
 				serviceProvider
 			);
 
@@ -45,7 +50,7 @@ describe('Component Factory', () => {
 
 		it('create nonexistent box throws', () => {
 			const factory = new ComponentFactory(
-				componentsDirWSlash,
+				componentsDir,
 				serviceProvider
 			);
 
@@ -61,7 +66,7 @@ describe('Component Factory', () => {
 		it('create a builtin box', async () => {
 			const multiFactory = new MultiComponentFactory();
 			multiFactory.push(
-				new ComponentFactory(componentsDir, serviceProvider)
+				new ComponentFactory(componentsDirSlash, serviceProvider)
 			);
 			multiFactory.push(
 				new ComponentFactory(testDataDir, serviceProvider)
@@ -74,7 +79,7 @@ describe('Component Factory', () => {
 		it('create a user-defined', async () => {
 			const multiFactory = new MultiComponentFactory();
 			multiFactory.push(
-				new ComponentFactory(componentsDir, serviceProvider)
+				new ComponentFactory(componentsDirSlash, serviceProvider)
 			);
 			multiFactory.push(
 				new ComponentFactory(testDataDir, serviceProvider)
@@ -86,7 +91,7 @@ describe('Component Factory', () => {
 
 		it('create nonexistent box throws', () => {
 			const factory = new ComponentFactory(
-				componentsDir,
+				componentsDirSlash,
 				serviceProvider
 			);
 

--- a/src/lib/bakeryjs/__tests__/ComponentFactory.test.ts
+++ b/src/lib/bakeryjs/__tests__/ComponentFactory.test.ts
@@ -10,6 +10,7 @@ const serviceProvider = new ServiceProvider({
 });
 
 const componentsDir = resolve(__dirname, '..', '..', '..', 'components') + '/';
+const componentsDirWSlash = resolve(__dirname, '..', '..', '..', 'components');
 const testDataDir =
 	resolve(__dirname, '..', '..', '..', '..', 'test-data') + '/';
 
@@ -28,6 +29,31 @@ describe('Component Factory', () => {
 			expect.assertions(2);
 			expect(reason).toBeInstanceOf(VError);
 			expect(reason.name).toBe('BoxNotFound');
+		});
+	});
+
+	describe('Component Factory -- path without ending slash', () => {
+		it('create builtin box', async () => {
+			const factory = new ComponentFactory(
+				componentsDirWSlash,
+				serviceProvider
+			);
+
+			const tickBox = await factory.create('tick');
+			expect(tickBox).not.toBeUndefined();
+		});
+
+		it('create nonexistent box throws', () => {
+			const factory = new ComponentFactory(
+				componentsDirWSlash,
+				serviceProvider
+			);
+
+			factory.create('fick').catch((reason) => {
+				expect.assertions(2);
+				expect(reason).toBeInstanceOf(VError);
+				expect(reason.name).toBe('BoxNotFound');
+			});
 		});
 	});
 


### PR DESCRIPTION
Fixes #5 

Additionally:
- I have replaced `forEach` with `for...of` which requires less nesting and should have better performance
- In tests, I have inlined path separators to `resolve` and swapped `componentsDir` with `componentsDirWSlash` to avoid repetition