### PR TITLE
Default priority is undefined.

### DIFF
--- a/src/lib/bakeryjs/queue/MemoryPriorityQueue.ts
+++ b/src/lib/bakeryjs/queue/MemoryPriorityQueue.ts
@@ -3,7 +3,7 @@ import {Message} from '../Message';
 import {qTrace, sampleStats} from '../stats';
 import BetterQueue = require('better-queue');
 
-const DEFAULT_PRIORITY = 5;
+const DEFAULT_PRIORITY = undefined;
 
 type TaskWrap<T> = {
 	m: T;


### PR DESCRIPTION
Priority of data generated will be undefined unless specified by the user.
The queue implementation penalizes putting prioritized messages into the long queue.
