### PR TITLE
Add paths mapping for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,15 @@
+const {pathsToModuleNameMapper} = require('ts-jest/utils');
+const {readFileSync} = require('fs');
+const JSON5 = require('json5');
+const {compilerOptions} = JSON5.parse(readFileSync('tsconfig.json').toString());
+
 module.exports = {
 	preset: 'ts-jest',
-	roots: ['<rootDir>/tests', '<rootDir>/src'],
 	testEnvironment: 'node',
 	collectCoverageFrom: ['src/**/*.{js,ts}'],
 	coverageReporters: ['text'],
-	moduleNameMapper: {
-		'^bakeryjs': '<rootDir>/src',
-	},
+	moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+		prefix: '<rootDir>/',
+	}),
+	testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -746,6 +746,12 @@
 												"ms": "2.0.0"
 										}
 								},
+								"json5": {
+										"version": "0.5.1",
+										"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+										"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+										"dev": true
+								},
 								"ms": {
 										"version": "2.0.0",
 										"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4577,10 +4583,21 @@
 						"dev": true
 				},
 				"json5": {
-						"version": "0.5.1",
-						"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-						"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-						"dev": true
+						"version": "2.1.0",
+						"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+						"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+						"dev": true,
+						"requires": {
+								"minimist": "^1.2.0"
+						},
+						"dependencies": {
+								"minimist": {
+										"version": "1.2.0",
+										"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+										"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+										"dev": true
+								}
+						}
 				},
 				"jsonfile": {
 						"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"eslint-plugin-typescript": "^0.14.0",
 		"jest": "^23.6.0",
 		"jest-junit": "^5.2.0",
+		"json5": "^2.1.0",
 		"nodemon": "^1.18.9",
 		"prettier": "1.15.3",
 		"ts-jest": "^23.10.5",
@@ -52,7 +53,7 @@
 	"scripts": {
 		"start": "npm run build:live",
 		"build:live": "nodemon --exec ./node_modules/.bin/ts-node -- ./src/index.ts all",
-		"build": "tsc --pretty",
+		"build": "tsc -b tsconfig.build.json",
 		"prepare": "npm run build",
 		"test": "jest",
 		"lint": "eslint --ext .ts,.js src/ tests/",

--- a/src/lib/bakeryjs/ComponentFactory.ts
+++ b/src/lib/bakeryjs/ComponentFactory.ts
@@ -1,12 +1,10 @@
-import * as fs from 'fs';
-import {join} from 'path';
 import {VError} from 'verror';
 import {BatchingBoxInterface, BoxInterface} from './BoxI';
 import ComponentFactoryI from './ComponentFactoryI';
 import {PriorityQueueI} from './queue/PriorityQueueI';
 import {Message} from './Message';
-import {parseComponentName} from './componentNameParser';
 import {ServiceProvider} from './ServiceProvider';
+import {scanComponentsPath} from './scanComponentsPath';
 
 const debug = require('debug')('bakeryjs:componentProvider');
 
@@ -37,7 +35,7 @@ export class ComponentFactory implements ComponentFactoryI {
 		serviceProvider: ServiceProvider
 	) {
 		this.baseURI = `file://${componentsPath}`;
-		this.findComponents(componentsPath);
+		this.availableComponents = scanComponentsPath(componentsPath);
 		debug(this.availableComponents);
 		this.serviceProvider = serviceProvider;
 	}
@@ -71,30 +69,6 @@ export class ComponentFactory implements ComponentFactoryI {
 				'Error loading component %s',
 				name
 			);
-		}
-	}
-
-	private findComponents(
-		componentsPath: string,
-		parentDir: string = ''
-	): void {
-		const files = fs.readdirSync(componentsPath);
-		for (const file of files) {
-			const stat = fs.statSync(join(componentsPath, file));
-			if (stat.isDirectory()) {
-				if (file !== '.' && file !== '..') {
-					this.findComponents(
-						join(componentsPath, file),
-						join(parentDir, file)
-					);
-				}
-			} else {
-				const name = parseComponentName(join(parentDir, file));
-				if (!name) {
-					continue;
-				}
-				this.availableComponents[name] = join(componentsPath, file);
-			}
 		}
 	}
 }

--- a/src/lib/bakeryjs/ComponentFactory.ts
+++ b/src/lib/bakeryjs/ComponentFactory.ts
@@ -48,7 +48,7 @@ export class ComponentFactory implements ComponentFactoryI {
 		parameters?: any
 	): Promise<BoxInterface | BatchingBoxInterface> {
 		if (!this.availableComponents[name]) {
-			return Promise.reject(boxNotFoundError(name, this.baseURI));
+			throw boxNotFoundError(name, this.baseURI);
 		}
 		try {
 			// TODO: (code detail) Is it necessary to always import the file?
@@ -60,19 +60,16 @@ export class ComponentFactory implements ComponentFactoryI {
 				parameters
 			) as BoxInterface | BatchingBoxInterface;
 		} catch (error) {
-			return Promise.reject(
-				new VError(
-					{
-						name: 'ComponentLoadError',
-						cause:
-							error instanceof Error ? error : new Error(error),
-						info: {
-							componentName: name,
-						},
+			throw new VError(
+				{
+					name: 'ComponentLoadError',
+					cause: error instanceof Error ? error : new Error(error),
+					info: {
+						componentName: name,
 					},
-					'Error loading component %s',
-					name
-				)
+				},
+				'Error loading component %s',
+				name
 			);
 		}
 	}
@@ -117,8 +114,10 @@ export class MultiComponentFactory implements ComponentFactoryI {
 		queue?: PriorityQueueI<Message>,
 		parameters?: any
 	): Promise<BoxInterface | BatchingBoxInterface> {
-		const futureBoxes = this.factories.map(async (f) => {
-			return await f.create(name, queue, parameters).catch((reason) => {
+		const futureBoxes = this.factories.map(async (factory) => {
+			try {
+				return await factory.create(name, queue, parameters);
+			} catch (reason) {
 				if (!(reason instanceof Error)) {
 					reason = new Error(reason);
 				}
@@ -131,14 +130,14 @@ export class MultiComponentFactory implements ComponentFactoryI {
 						name: 'FactoryException',
 						message: 'ComponentFactory.create(%s) failed.',
 						info: {
-							factoryBaseURI: f.baseURI,
+							factoryBaseURI: factory.baseURI,
 							requestedBoxName: name,
 						},
 						cause: reason,
 					},
 					name
 				);
-			});
+			}
 		});
 
 		const resolvedBoxes = await Promise.all(futureBoxes);
@@ -147,8 +146,6 @@ export class MultiComponentFactory implements ComponentFactoryI {
 			return result;
 		}
 
-		return Promise.reject(
-			boxNotFoundError(name, this.factories.map((f) => f.baseURI))
-		);
+		throw boxNotFoundError(name, this.factories.map((f) => f.baseURI));
 	}
 }

--- a/src/lib/bakeryjs/scanComponentsPath.ts
+++ b/src/lib/bakeryjs/scanComponentsPath.ts
@@ -1,0 +1,36 @@
+import {join} from 'path';
+import * as fs from 'fs';
+import {parseComponentName} from './componentNameParser';
+
+type ComponentsMap = {[componentName: string]: string};
+
+// TODO: Make async
+function scanComponentsPath(
+	componentsPath: string,
+	parentDir: string = '',
+	availableComponents: ComponentsMap = {}
+): ComponentsMap {
+	const files = fs.readdirSync(componentsPath);
+	for (const file of files) {
+		const filePath = join(componentsPath, file);
+		const stat = fs.statSync(filePath);
+		if (stat.isDirectory()) {
+			if (file !== '.' && file !== '..') {
+				scanComponentsPath(
+					filePath,
+					join(parentDir, file),
+					availableComponents
+				);
+			}
+		} else {
+			const name = parseComponentName(join(parentDir, file));
+			if (!name) {
+				continue;
+			}
+			availableComponents[name] = filePath;
+		}
+	}
+	return availableComponents;
+}
+
+export {scanComponentsPath};

--- a/test-data/generators/bad.ts
+++ b/test-data/generators/bad.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from './../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/generators/hellobatchworld.ts
+++ b/test-data/generators/hellobatchworld.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from './../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/generators/helloworld.ts
+++ b/test-data/generators/helloworld.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from './../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/processors/checksum.ts
+++ b/test-data/processors/checksum.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from './../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/processors/punctcount.ts
+++ b/test-data/processors/punctcount.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from './../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/processors/wordbatchcount.ts
+++ b/test-data/processors/wordbatchcount.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from '../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/processors/wordbatchcountslow.ts
+++ b/test-data/processors/wordbatchcountslow.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from '../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/test-data/processors/wordcount.ts
+++ b/test-data/processors/wordcount.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from './../../src';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 module.exports = boxFactory(
 	{

--- a/tests/components/_/generators/tick.ts
+++ b/tests/components/_/generators/tick.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from '../../../';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 const Tick = boxFactory(
 	{

--- a/tests/components/_/generators/tick.ts
+++ b/tests/components/_/generators/tick.ts
@@ -1,0 +1,31 @@
+import {boxFactory, ServiceProvider, MessageData} from '../../../';
+
+const Tick = boxFactory(
+	{
+		requires: ['jobId'],
+		provides: ['raw'],
+		emits: ['tick'],
+		aggregates: false,
+	},
+	function processValue(
+		serviceProvider: ServiceProvider,
+		value: MessageData,
+		emitCallback: (chunk: MessageData[], priority?: number) => void
+	): Promise<any> {
+		let i = 0;
+		return new Promise(
+			(resolve: (result?: any) => void): void => {
+				const id = setInterval((): void => {
+					if (i >= 3) {
+						clearInterval(id);
+						resolve();
+					}
+					i += 1;
+					emitCallback([{raw: i}], 1);
+				}, 1000);
+			}
+		);
+	}
+);
+
+export default Tick;

--- a/tests/components/_/generators/tock.ts
+++ b/tests/components/_/generators/tock.ts
@@ -1,0 +1,31 @@
+import {boxFactory, ServiceProvider, MessageData} from '../../..';
+
+const Tock = boxFactory(
+	{
+		requires: ['jobId'],
+		provides: ['raw'],
+		emits: ['tock'],
+		aggregates: false,
+	},
+	function processValue(
+		serviceProvider: ServiceProvider,
+		value: MessageData,
+		emitCallback: (chunk: MessageData[], priority?: number) => void
+	): Promise<any> {
+		let i = 0;
+		return new Promise(
+			(resolve: (result?: any) => void): void => {
+				const id = setInterval((): void => {
+					if (i >= 3) {
+						clearInterval(id);
+						resolve();
+					}
+					i += 1;
+					emitCallback([{raw: i}], 1);
+				}, 1000);
+			}
+		);
+	}
+);
+
+export default Tock;

--- a/tests/components/_/generators/tock.ts
+++ b/tests/components/_/generators/tock.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from '../../..';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 const Tock = boxFactory(
 	{

--- a/tests/components/_/processors/print.ts
+++ b/tests/components/_/processors/print.ts
@@ -1,0 +1,19 @@
+import {boxFactory, ServiceProvider, MessageData} from '../../../';
+
+const Print = boxFactory(
+	{
+		requires: ['jobId', 'raw'],
+		provides: [],
+		emits: [],
+		aggregates: false,
+	},
+	function processValue(
+		services: ServiceProvider,
+		input: MessageData,
+		neverEmit: (chunk: MessageData[], priority?: number) => void
+	): MessageData {
+		services.get('logger').log({printBox: JSON.stringify(input)});
+		return {};
+	}
+);
+export default Print;

--- a/tests/components/_/processors/print.ts
+++ b/tests/components/_/processors/print.ts
@@ -1,4 +1,4 @@
-import {boxFactory, ServiceProvider, MessageData} from '../../../';
+import {boxFactory, ServiceProvider, MessageData} from 'bakeryjs';
 
 const Print = boxFactory(
 	{

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -1,8 +1,7 @@
-import {Program} from '../src';
-import {MessageData} from '../src/lib/bakeryjs/Message';
-import {FlowDescription} from '../src/lib/bakeryjs/Flow';
-import {FlowExplicitDescription} from '../src/lib/bakeryjs/FlowBuilderI';
 import * as VError from 'verror';
+import {Program, MessageData} from 'bakeryjs';
+import {FlowExplicitDescription} from 'bakeryjs/FlowBuilderI';
+import {FlowDescription} from 'bakeryjs/Flow';
 
 const program = new Program(
 	{},

--- a/tests/regressions.test.ts
+++ b/tests/regressions.test.ts
@@ -1,4 +1,4 @@
-import {Program} from '../src';
+import {Program} from 'bakeryjs';
 
 test('tracingModel: TypeError: Requested key msg is missing', async () => {
 	const program = new Program(

--- a/tests/scanComponentsPath.int.test.ts
+++ b/tests/scanComponentsPath.int.test.ts
@@ -4,7 +4,7 @@ import {scanComponentsPath} from 'bakeryjs/scanComponentsPath';
 const componentsPath = join(__dirname, 'components');
 
 describe('.scanComponentsPath', () => {
-	it('finds all components in a directory', () => {
+	it('finds components in a directory', () => {
 		const result = scanComponentsPath(componentsPath);
 		expect(result).toEqual(
 			expect.objectContaining({
@@ -12,6 +12,14 @@ describe('.scanComponentsPath', () => {
 				tock: join(componentsPath, '_/generators/tock.ts'),
 				print: join(componentsPath, '_/processors/print.ts'),
 			})
+		);
+	});
+	it('ignores invalid files', () => {
+		const result = scanComponentsPath(componentsPath);
+		expect(Object.keys(result)).toEqual(
+			expect.not.arrayContaining([
+				expect.stringContaining('not-a-component'),
+			])
 		);
 	});
 });

--- a/tests/scanComponentsPath.int.test.ts
+++ b/tests/scanComponentsPath.int.test.ts
@@ -1,0 +1,17 @@
+import {join} from 'path';
+import {scanComponentsPath} from 'bakeryjs/scanComponentsPath';
+
+const componentsPath = join(__dirname, 'components');
+
+describe('.scanComponentsPath', () => {
+	it('finds all components in a directory', () => {
+		const result = scanComponentsPath(componentsPath);
+		expect(result).toEqual(
+			expect.objectContaining({
+				tick: join(componentsPath, '_/generators/tick.ts'),
+				tock: join(componentsPath, '_/generators/tock.ts'),
+				print: join(componentsPath, '_/processors/print.ts'),
+			})
+		);
+	});
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "**/node_modules/*", "**/__tests__/*"],
+	"compilerOptions": {
+		"pretty": true
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,71 +1,63 @@
 {
-  "compileOnSave": true,
-  "compilerOptions": {
-    /* Basic Options */
-    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["esnext"],                         /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": false,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "build",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+	"compilerOptions": {
+		/* Basic Options */
+		"target": "es2017",
+		"module": "commonjs",
+		"lib": ["esnext"],
+		// "allowJs": true,                       /* Allow javascript files to be compiled. */
+		// "checkJs": true,                       /* Report errors in .js files. */
+		// "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+		"declaration": true /* Generates corresponding '.d.ts' file. */,
+		// "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+		"sourceMap": true /* Generates corresponding '.map' file. */,
+		// "outFile": "./",                       /* Concatenate and emit output to single file. */
+		"outDir": "build",
+		// "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		// "composite": true,                     /* Enable project compilation */
+		// "removeComments": true,                /* Do not emit comments to output. */
+		// "noEmit": true,                        /* Do not emit outputs. */
+		// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+		// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true,              /* Enable strict null checks. */
-    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+		/* Strict Type-Checking Options */
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"strictBindCallApply": true,
+		"strictPropertyInitialization": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true,
 
-    /* Additional Checks */
-    "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+		/* Additional Checks */
+		"noUnusedLocals": true /* Report errors on unused locals. */,
+		// "noUnusedParameters": true,            /* Report errors on unused parameters. */
+		"noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+		// "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
-    /* Module Resolution Options */
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
-    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      "*": [
-        "node_modules/*",
-        "src/types/*"
-      ]
-    },
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+		/* Module Resolution Options */
+		"moduleResolution": "node",
+		"baseUrl": "./",
+		"paths": {
+			"bakeryjs": ["src/index.ts"],
+			"bakeryjs/*": ["src/lib/bakeryjs/*"]
+		},
+		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+		// "typeRoots": [],                       /* List of folders to include type definitions from. */
+		// "types": [],                           /* Type declaration files to be included in compilation. */
+		// "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		"esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+		/* Source Map Options */
+		// "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+		// "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+		// "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
-    /* Experimental Options */
-    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+		/* Experimental Options */
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": true
+	}
 }


### PR DESCRIPTION
Avoid long relative paths to the main file like `../../../src` with paths mapping. This also requires a separate `tsconfig` file specific for builds, with explicit includes and excludes, otherwise VSCode won't pick any files outside of `src/`. The side advantage is we can easily exclude tests and other files from the build now.