### PR TITLE
Fix: One dimension completes before the other starts

### DIFF
--- a/src/lib/bakeryjs/tracingModel.ts
+++ b/src/lib/bakeryjs/tracingModel.ts
@@ -408,6 +408,12 @@ export class TracingModel {
 		parentMsgId: string,
 		dimension: string[]
 	) {
+		// The dimension may even have not started yet! The first message of the dimension
+		// can be still in its 1st box.
+		if (!this.msgStore.get(parentMsgId).has(dimension)) {
+			return;
+		}
+
 		const dimensionDone =
 			this.dimensionStore.get(parentMsgId).get(dimension).complete &&
 			Array.from(

--- a/test-data/generators/bad.ts
+++ b/test-data/generators/bad.ts
@@ -4,7 +4,7 @@ module.exports = boxFactory(
 	{
 		provides: ['msg'],
 		requires: [],
-		emits: ['msg'],
+		emits: ['msg_bad'],
 		aggregates: false,
 	},
 	async function(

--- a/test-data/generators/hellobatchworld.ts
+++ b/test-data/generators/hellobatchworld.ts
@@ -4,7 +4,7 @@ module.exports = boxFactory(
 	{
 		provides: ['msg'],
 		requires: [],
-		emits: ['msg'],
+		emits: ['msg_hellobatchworld'],
 		aggregates: false,
 	},
 	async function(

--- a/test-data/generators/helloworld.ts
+++ b/test-data/generators/helloworld.ts
@@ -4,7 +4,7 @@ module.exports = boxFactory(
 	{
 		provides: ['msg'],
 		requires: [],
-		emits: ['msg'],
+		emits: ['msg_helloworld'],
 		aggregates: false,
 	},
 	async function(

--- a/tests/regressions.test.ts
+++ b/tests/regressions.test.ts
@@ -1,13 +1,19 @@
 import {Program} from 'bakeryjs';
 
-test('tracingModel: TypeError: Requested key msg is missing', async () => {
+test('tracingModel: One dimension completes before the other starts. TypeError: Requested key msg is missing', async () => {
 	const program = new Program(
 		{},
 		{componentPaths: [`${__dirname}/../test-data/`]}
 	);
 
 	const job = {
-		process: [[{hellobatchworld: [['wordbatchcountslow']]}]],
+		process: [
+			[
+				{
+					hellobatchworld: [['wordbatchcountslow']],
+					helloworld: [['wordcount']]
+				}
+			]],
 	};
 
 	await program.run(job);


### PR DESCRIPTION
Fixes #29

The problem is in parallel generating dimensions  when the first is complete before the second actually starts.  Then the second dimension has the tracing structure built but it is empty as no message about box of dimension completeness has arrived yet.

The fix is to check whether the dimension structure is present in the parent message store.  If not, the job is simply not done.